### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/grafana/defaults.yaml
+++ b/grafana/defaults.yaml
@@ -8,8 +8,8 @@ grafana:
   pkg:
     name: grafana
     binary: grafana
-    use_upstream_archive: False
-    use_upstream_repo: False
+    use_upstream_archive: false
+    use_upstream_repo: false
     repo:
       humanname: grafana
       name: grafana
@@ -22,13 +22,14 @@ grafana:
       uri: https://dl.grafana.com/oss/release
       source: None
       source_hash: None
-      trim_output: True   {# works in 2018.3.2. onwards #}
+      trim_output: true  # works in 2018.3.2. onwards
       archive_suffix: tar.gz
       archive_format: tar
-      enforce_toplevel: False         # needed for grafana
-      options: '--strip-components=1' # needed for grafana
+      enforce_toplevel: false          # needed for grafana
+      options: '--strip-components=1'  # needed for grafana
 
-  kernel: {{ grains.kernel | lower }}
+  # Provided in `map.jinja` via. `grains.kernel`
+  kernel: ''
   rootgroup: root
   group: grafana
   config_file: /etc/grafana/grafana.ini
@@ -41,5 +42,5 @@ grafana:
     group: grafana
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 0

--- a/grafana/map.jinja
+++ b/grafana/map.jinja
@@ -26,6 +26,20 @@
 {#- Merge the grafana pillar #}
 {%- set grafana = salt['pillar.get']('grafana', default=defaults, merge=True) %}
 
+{#- Post-processing for specific non-YAML customisations #}
+{%- do grafana.update({'kernel': grains.kernel | lower}) %}
+{#- TODO: `grafana.rootuser` and `grafana.service.rootgroup` are ununsed in this formula #}
+{#- * https://github.com/saltstack-formulas/grafana-formula/search?q=rootuser&unscoped_q=rootuser #}
+{#- * https://github.com/saltstack-formulas/grafana-formula/search?q=rootgroup&unscoped_q=rootgroup #}
+{%- if grains.os == 'MacOS' %}
+{%-   set macos_user = salt['cmd.run']("stat -f '%Su' /dev/console") %}
+{%-   set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+{%-   do grafana.update({'rootuser': macos_user}) %}
+{%-   do grafana.update({'rootgroup': macos_group}) %}
+{%-   do grafana.service.update({'rootgroup': macos_group}) %}
+{%-   do grafana.service.update({'group': macos_group}) %}
+{%- endif %}
+
 {#- archive jinja #}
 {%- if grafana.pkg.use_upstream_archive %}
     {%- set name = 'grafana-%s.%s-%s'|format(grafana.version, grafana.kernel, grafana.arch) %}

--- a/grafana/osfamilymap.yaml
+++ b/grafana/osfamilymap.yaml
@@ -10,14 +10,9 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfamilymap: {}
 ---
-{%- if grains.os == 'MacOS' %}
-  {% set macos_user = salt['cmd.run']("stat -f '%Su' /dev/console") %}
-  {% set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
-{%- endif %}
-
 Debian:
   pkg:
-    use_upstream_repo: True
+    use_upstream_repo: true
     repo:
       humanname: grafana_official
       name: deb https://packages.grafana.com/oss/deb stable main
@@ -26,7 +21,7 @@ Debian:
 
 RedHat:
   pkg:
-    use_upstream_repo: True
+    use_upstream_repo: true
     repo:
       baseurl: https://packages.grafana.com/oss/rpm-beta
       repo_gpgcheck: 1
@@ -38,7 +33,7 @@ RedHat:
 
 Suse:
   pkg:
-    use_upstream_repo: True
+    use_upstream_repo: true
     repo:
       baseurl: https://packages.grafana.com/oss/rpm-beta
       repo_gpgcheck: 1
@@ -82,10 +77,5 @@ Windows:
       archive_format: zip
 
 MacOS:
-  rootuser: {{ macos_user | d('') }}
-  rootgroup: {{ macos_group | d('') }}
-  group: {{ macos_group | d('') }}
   service:
     name: grafana
-    rootgroup: {{ macos_group | d('') }}
-    group: {{ macos_group | d('') }}

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@
 grafana:
   pkg:
     name: grafana
-    use_upstream_archive: False
+    use_upstream_archive: false
     archive:
       uri: https://dl.grafana.com/oss/release
     repo:
@@ -45,11 +45,10 @@ grafana:
     # dirs:
     #   files: files_alt
     #   default: default_alt
-    # source_files:
-    #   grafana-config-file-file-managed:
-    #     - 'example_alt.tmpl'
-    #     - 'example_alt.tmpl.jinja'
+    source_files:
+      grafana-config-file-file-managed-config_file:
+        - 'alt_grafana.ini.jinja'
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 1000

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: grafana formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
grafana-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./grafana/defaults.yaml
  11:27     warning  truthy value should be one of [false, true]  (truthy)
  12:24     warning  truthy value should be one of [false, true]  (truthy)
  25:57     warning  too few spaces before comment  (comments)
  25:58     warning  missing starting space in comment  (comments)
  28:25     warning  truthy value should be one of [false, true]  (truthy)
  29:39     warning  too few spaces before comment  (comments)
  31:13     error    too many spaces inside braces  (braces)
  31:35     error    too many spaces inside braces  (braces)
  44:6      warning  missing starting space in comment  (comments)

./grafana/osfamilymap.yaml
  13:2      error    syntax error: found character '%' that cannot start any token

pillar.example
  7:27      warning  truthy value should be one of [false, true]  (truthy)
  42:5      warning  comment not indented like content  (comments-indentation)
  54:6      warning  missing starting space in comment  (comments)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.